### PR TITLE
fix: check if interceptor IDs are not numeric

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -60,11 +60,11 @@ export const setAuthHeader = (token, onInvalidToken) => {
 };
 
 export const removeAuthHeader = () => {
-  if (reqInterceptor) {
+  if (reqInterceptor != null) {
     apiClient.interceptors.request.eject(reqInterceptor);
     reqInterceptor = null;
   }
-  if (resInterceptor) {
+  if (resInterceptor != null) {
     apiClient.interceptors.response.eject(resInterceptor);
     resInterceptor = null;
   }


### PR DESCRIPTION
## Details

Since a value of `0` is a falsy value, the first interceptor was not being ejected from the Axios instance.

Now the validation is done by checking if the ID variable is `null` or `undefined`.